### PR TITLE
Add automatic Github release and compiled binary upload on branch tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Build/release
+
+on: push
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v1
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.17'
+          cache: 'npm'
+      
+      - name: Install node modules 
+        run: npm install
+
+      - name: Build/release Electron app
+        uses: samuelmeuli/action-electron-builder@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          release: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ on:
     tags:
       - "v*"
 
-jobs:
-  release:
+jobs:                    
+  build:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -15,19 +15,49 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
         with:
           node-version: '14.17'
-          cache: 'npm'
-      
+
+      - name: Cache Node modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-wp-${{ hashFiles('**/package-lock.json') }}
+
       - name: Install node modules 
         run: npm install
 
-      - name: Build/release Electron app
+      - name: Build Electron app
         uses: samuelmeuli/action-electron-builder@v1
         with:
-          github_token: ${{ secrets.github_token }}
-          release: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release: false
+
+      - name: Store Build 
+        uses: actions/upload-artifact@v2
+        with:
+          name: electron-build
+          path: |
+            electron/output/*.exe
+            electron/output/*.AppImage
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [build]
+
+    steps:
+      - name: Get node artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: electron-build
+          path: electron/output      
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            electron/output/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
-name: Build/release
+name: Version Release
 
-on: push
+on:
+  push:
+    tags:
+      - "v*"
 
 jobs:
   release:


### PR DESCRIPTION
This PR will create a new action which can be triggered on tagging for automatically creating and uploading binary builds on the repo's release page.

Example:

![Screenshot 2021-08-01 001536](https://user-images.githubusercontent.com/1405327/127754465-3d4a5bab-22fd-4725-9aab-2640a838cce5.png)
